### PR TITLE
Ta i bruk integrasjoner sin tjeneste for saksbehandlers enhet

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/klage/Felles.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/klage/Felles.kt
@@ -105,11 +105,3 @@ fun <T> Ressurs<T>.getDataOrThrow(): T {
 data class PersonIdent(
     @field:Pattern(regexp = "(^$|.{11})", message = "PersonIdent er ikke riktig") val ident: String,
 )
-
-class Saksbehandler(
-    val azureId: UUID,
-    val navIdent: String,
-    val fornavn: String,
-    val etternavn: String,
-    val enhet: String,
-)

--- a/src/main/kotlin/no/nav/tilleggsstonader/klage/integrasjoner/TilleggsstønaderIntegrasjonerClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/klage/integrasjoner/TilleggsstønaderIntegrasjonerClient.kt
@@ -1,7 +1,9 @@
 package no.nav.tilleggsstonader.klage.integrasjoner
 
 import no.nav.familie.http.client.AbstractPingableRestClient
+import no.nav.tilleggsstonader.kontrakter.felles.Saksbehandler
 import no.nav.familie.log.NavHttpHeaders
+import no.nav.tilleggsstonader.klage.felles.util.medContentTypeJsonUTF8
 import no.nav.tilleggsstonader.klage.infrastruktur.config.IntegrasjonerConfig
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.ArkiverDokumentRequest
 import no.nav.tilleggsstonader.kontrakter.dokarkiv.ArkiverDokumentResponse
@@ -72,6 +74,13 @@ class TilleggsstønaderIntegrasjonerClient(
                 .build()
                 .toUri(),
         )
+
+    fun hentSaksbehandlerInfo(navIdent: String): Saksbehandler {
+        return getForEntity<Saksbehandler>(
+            URI.create("$saksbehandlerUri/$navIdent"),
+            HttpHeaders().medContentTypeJsonUTF8(),
+        )
+    }
 
     private fun headerMedSaksbehandler(saksbehandler: String?): HttpHeaders {
         val httpHeaders = HttpHeaders()

--- a/src/main/kotlin/no/nav/tilleggsstonader/klage/kabal/KabalService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/klage/kabal/KabalService.kt
@@ -16,9 +16,8 @@ class KabalService(
 ) {
 
     fun sendTilKabal(fagsak: Fagsak, behandling: Behandling, vurdering: Vurdering, saksbehandlerIdent: String) {
-        // TODO: Finn en måte å hente ut saksbehandlers enhet på, slik at riktig enhet kan settes her
-        val tilleggsstønaderInnEnhet = "4462"
-        val oversendtKlageAnkeV3 = lagKlageOversendelseV3(fagsak, behandling, vurdering, tilleggsstønaderInnEnhet)
+        val tilleggsstønaderInnEnhet = integrasjonerClient.hentSaksbehandlerInfo(saksbehandlerIdent)
+        val oversendtKlageAnkeV3 = lagKlageOversendelseV3(fagsak, behandling, vurdering, tilleggsstønaderInnEnhet.enhet)
         kabalClient.sendTilKabal(oversendtKlageAnkeV3)
     }
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/klage/infrastruktur/config/FamilieIntegrasjonerMock.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/klage/infrastruktur/config/FamilieIntegrasjonerMock.kt
@@ -10,7 +10,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.post
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching
-import no.nav.tilleggsstonader.klage.Saksbehandler
+import no.nav.tilleggsstonader.kontrakter.felles.Saksbehandler
 import no.nav.tilleggsstonader.klage.infrastruktur.config.PdfMock.pdfAsBase64String
 import no.nav.tilleggsstonader.klage.integrasjoner.TilleggsstønaderIntegrasjonerClient
 import no.nav.tilleggsstonader.kontrakter.felles.BrukerIdType

--- a/src/test/kotlin/no/nav/tilleggsstonader/klage/kabal/KabalServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/klage/kabal/KabalServiceTest.kt
@@ -5,7 +5,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
-import no.nav.tilleggsstonader.klage.Saksbehandler
+import no.nav.tilleggsstonader.kontrakter.felles.Saksbehandler
 import no.nav.tilleggsstonader.klage.behandling.domain.PåklagetVedtak
 import no.nav.tilleggsstonader.klage.behandling.domain.PåklagetVedtakstype
 import no.nav.tilleggsstonader.klage.fagsak.domain.PersonIdent
@@ -41,6 +41,13 @@ internal class KabalServiceTest {
     @BeforeEach
     internal fun setUp() {
         every { kabalClient.sendTilKabal(capture(oversendelseSlot)) } just Runs
+        every { integrasjonerClient.hentSaksbehandlerInfo(any()) } answers {
+            when (firstArg<String>()) {
+                saksbehandlerA.navIdent -> saksbehandlerA
+                saksbehandlerB.navIdent -> saksbehandlerB
+                else -> error("Fant ikke info om saksbehanlder ${firstArg<String>()}")
+            }
+        }
     }
 
     @Test
@@ -82,8 +89,7 @@ internal class KabalServiceTest {
         assertThat(oversendelseSlot.captured.forrigeBehandlendeEnhet).isEqualTo(saksbehandlerB.enhet)
     }
 
-    // TODO: Fjern disable når man har funnet en måte å hente ut saksbehandlers enhet på, slik at riktig enhet kan settes her
-    @Disabled
+
     @Test
     internal fun `skal feile hvis saksbehandlerinfo ikke finnes`() {
         val behandling = behandling(fagsak, påklagetVedtak = PåklagetVedtak(PåklagetVedtakstype.UTEN_VEDTAK))

--- a/src/test/kotlin/no/nav/tilleggsstonader/klage/kabal/event/BehandlingEventServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/klage/kabal/event/BehandlingEventServiceTest.kt
@@ -6,7 +6,7 @@ import io.mockk.slot
 import io.mockk.verify
 import no.nav.familie.prosessering.domene.Task
 import no.nav.familie.prosessering.internal.TaskService
-import no.nav.tilleggsstonader.klage.Saksbehandler
+import no.nav.tilleggsstonader.kontrakter.felles.Saksbehandler
 import no.nav.tilleggsstonader.klage.behandling.BehandlingRepository
 import no.nav.tilleggsstonader.klage.behandling.StegService
 import no.nav.tilleggsstonader.klage.behandling.domain.StegType
@@ -58,6 +58,7 @@ internal class BehandlingEventServiceTest {
         every { behandlingRepository.findByEksternBehandlingId(any()) } returns behandlingMedStatusVenter
         every { klageresultatRepository.insert(any()) } answers { firstArg() }
         every { klageresultatRepository.existsById(any()) } returns false
+        every { integrasjonerClient.hentSaksbehandlerInfo(any()) } returns saksbehandler
     }
 
     @Test
@@ -173,7 +174,7 @@ internal class BehandlingEventServiceTest {
         return BehandlingEvent(
             eventId = UUID.randomUUID(),
             kildeReferanse = UUID.randomUUID().toString(),
-            kilde = "EF",
+            kilde = "TS",
             kabalReferanse = "kabalReferanse",
             type = behandlingEventType,
             detaljer = behandlingDetaljer ?: BehandlingDetaljer(
@@ -185,4 +186,11 @@ internal class BehandlingEventServiceTest {
             ),
         )
     }
+    private val saksbehandler = Saksbehandler(
+        UUID.randomUUID(),
+        "A123456",
+        "Alfa",
+        "Omega",
+        "4402"
+    )
 }


### PR DESCRIPTION
Legge til at saksbehandlers enhet blir sendt til kabal.
Aktivere og legge til tester for elementet saksbehandler
Bytte ut lokalt domeneobjekt for Saksbehandler med objekt fra kontrakter.