### PR TITLE
🐛 Legger til ny type for "ANKE_I_TRYGDERETTEN"

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/klage/kabal/domain/OversendtKlage.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/klage/kabal/domain/OversendtKlage.kt
@@ -22,9 +22,10 @@ data class OversendtKlageAnkeV3(
     val kommentar: String? = null,
 )
 
-enum class Type(override val id: String, override val navn: String, override val beskrivelse: String) : Kode {
-    KLAGE("1", "Klage", "Klage"),
-    ANKE("2", "Anke", "Anke"),
+enum class Type(val beskrivelse: String) {
+    KLAGE("Klage"),
+    ANKE("Anke"),
+    ANKE_I_TRYGDERETTEN("Anke i trygderetten"),
 }
 
 enum class OversendtPartIdType {


### PR DESCRIPTION
Denne ligger i [skjemaet til kabal](https://github.com/navikt/kabal-api/blob/91333472a747158d923fd644a950a8536c2341d5/docs/schema/behandling-events.json#L203), og har nå oppstått i prod og gir feil i prod.