### PR TITLE
Skal opprette behandle-sak oppgaver i klar-mappen for at saksbehandle…

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/klage/oppgave/OpprettBehandleSakOppgaveTask.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/klage/oppgave/OpprettBehandleSakOppgaveTask.kt
@@ -48,6 +48,7 @@ class OpprettBehandleSakOppgaveTask(
             behandlesAvApplikasjon = "tilleggsstonader-klage",
             tilordnetRessurs = task.metadata.getProperty(saksbehandlerMetadataKey),
             behandlingstema = if (klageGjelderTilbakekreving) Behandlingstema.Tilbakebetaling.value else null,
+            mappeId = oppgaveService.finnMappe(behandling.behandlendeEnhet, OppgaveMappe.KLAR),
         )
 
         val oppgaveId = oppgaveService.opprettOppgave(opprettOppgaveRequest = oppgaveRequest)


### PR DESCRIPTION
…re ikke skal se oppgaven i gosys i uplassert når de har gosys-vakt

Jeg tenker at `OpprettKabalEventOppgaveTask` som oppretter oppgavetype `VurderKonsekvensForYtelse` ikke skal ha mappe, men at den skal opprette en oppgave som blir plassert i uplasserte og er en del av gosys-vaktens jobb å sjekke? 
De kan likevel ikke håndtere den typen oppgaver i vår oppgavebenk vel? 

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21920