### PR TITLE
Legg til felt harFullmakt til personoppplysninger

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/klage/felles/util/DatoUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/klage/felles/util/DatoUtil.kt
@@ -1,0 +1,5 @@
+package no.nav.tilleggsstonader.klage.felles.util
+
+import java.time.LocalDate
+
+fun LocalDate.isEqualOrBefore(other: LocalDate) = this == other || this.isBefore(other)

--- a/src/main/kotlin/no/nav/tilleggsstonader/klage/fullmakt/FullmaktClient.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/klage/fullmakt/FullmaktClient.kt
@@ -1,0 +1,30 @@
+package no.nav.tilleggsstonader.klage.fullmakt
+
+import no.nav.tilleggsstonader.kontrakter.felles.IdentRequest
+import no.nav.tilleggsstonader.kontrakter.fullmakt.FullmektigDto
+import no.nav.tilleggsstonader.libs.http.client.AbstractRestClient
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import org.springframework.web.client.RestTemplate
+import org.springframework.web.util.UriComponentsBuilder
+import java.net.URI
+
+@Service
+class FullmaktClient(
+    @Qualifier("azure") restTemplate: RestTemplate,
+    @Value("\${TILLEGGSSTONADER_INTEGRASJONER_URL}")
+    private val integrasjonUri: URI,
+) : AbstractRestClient(restTemplate) {
+
+    private val uriFullmektige = UriComponentsBuilder.fromUri(integrasjonUri)
+        .pathSegment("api", "fullmakt", "fullmektige")
+        .encode().toUriString()
+
+    fun hentFullmektige(fullmaktsgiversIdent: String): List<FullmektigDto> {
+        return postForEntity(
+            uri = uriFullmektige,
+            payload = IdentRequest(fullmaktsgiversIdent),
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/tilleggsstonader/klage/fullmakt/FullmaktService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/klage/fullmakt/FullmaktService.kt
@@ -1,0 +1,34 @@
+package no.nav.tilleggsstonader.klage.fullmakt
+
+import no.nav.tilleggsstonader.klage.felles.util.isEqualOrBefore
+import no.nav.tilleggsstonader.kontrakter.felles.Tema
+import no.nav.tilleggsstonader.kontrakter.fullmakt.FullmektigDto
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import java.time.LocalDate.now
+
+@Component
+class FullmaktService(
+    val fullmaktClient: FullmaktClient,
+) {
+    val log: Logger = LoggerFactory.getLogger(javaClass)
+
+    fun hentFullmektige(fullmaktsgiversIdent: String): List<FullmektigDto> {
+        return try {
+            fullmaktClient.hentFullmektige(fullmaktsgiversIdent)
+                .filter { it.gjelderTilleggsstønader() }
+                .filter { it.erAktiv() }
+        } catch (ex: Exception) {
+            log.error("Kunne ikke hente fullmakter: {}", ex.message)
+            emptyList()
+        }
+    }
+}
+
+private fun FullmektigDto.gjelderTilleggsstønader() =
+    temaer.any { tema -> tema in listOf(Tema.TSO.name, Tema.TSR.name) }
+
+private fun FullmektigDto.erAktiv() =
+    gyldigFraOgMed.isEqualOrBefore(now()) &&
+        (gyldigTilOgMed == null || gyldigTilOgMed!!.isAfter(now()))

--- a/src/main/kotlin/no/nav/tilleggsstonader/klage/personopplysninger/dto/PersonopplysningerDto.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/klage/personopplysninger/dto/PersonopplysningerDto.kt
@@ -11,6 +11,7 @@ data class PersonopplysningerDto(
     val dødsdato: LocalDate?,
     val fullmakt: List<FullmaktDto>,
     val egenAnsatt: Boolean,
+    val harFullmektig: Boolean,
     val vergemål: List<VergemålDto>,
 )
 

--- a/src/test/kotlin/no/nav/tilleggsstonader/klage/KlageAppLocal.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/klage/KlageAppLocal.kt
@@ -18,6 +18,7 @@ fun main(args: Array<String>) {
             "mock-integrasjoner",
             "mock-auditlogger",
             "mock-pdl",
+            "mock-fullmakt",
             "mock-brev",
             "mock-tilleggsstonader-sak",
             "mock-dokument",

--- a/src/test/kotlin/no/nav/tilleggsstonader/klage/fullmakt/FullmaktServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/klage/fullmakt/FullmaktServiceTest.kt
@@ -1,0 +1,43 @@
+package no.nav.tilleggsstonader.klage.fullmakt
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.tilleggsstonader.klage.testutil.FullmektigStubs
+import no.nav.tilleggsstonader.kontrakter.fullmakt.FullmektigDto
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class FullmaktServiceTest {
+    private val mockFullmaktClient = mockk<FullmaktClient>()
+    private val serviceUnderTest = FullmaktService(mockFullmaktClient)
+
+    @Test
+    fun `hentFullmektige skal filtere bort inaktive fullmakter`() {
+        mockFullmektigeRespons(listOf(FullmektigStubs.ikkeGyldigEnda, FullmektigStubs.utgått))
+        val resultat = serviceUnderTest.hentFullmektige(dummyIdent)
+        assertEquals(emptyList<FullmektigDto>(), resultat)
+    }
+
+    @Test
+    fun `hentFullmektige tar bare med fullmakter med Tilleggsstønad-tema`() {
+        mockFullmektigeRespons(listOf(FullmektigStubs.ikkeRelevantTema, FullmektigStubs.medFlereTemaer))
+        val resultat = serviceUnderTest.hentFullmektige(dummyIdent)
+        assertThat(resultat.size).isEqualTo(1)
+        assertEquals(resultat.first(), FullmektigStubs.medFlereTemaer)
+    }
+
+    @Test
+    fun `hentFullmektige inkluderer fullmakter med ubegrenset gyldighetsperiode`() {
+        mockFullmektigeRespons(listOf(FullmektigStubs.gyldigPåUbestemtTid))
+        val resultat = serviceUnderTest.hentFullmektige(dummyIdent)
+        assertThat(resultat.size).isEqualTo(1)
+        assertEquals(resultat.first(), FullmektigStubs.gyldigPåUbestemtTid)
+    }
+
+    private fun mockFullmektigeRespons(fullmakter: List<FullmektigDto>) {
+        every { mockFullmaktClient.hentFullmektige(any()) } returns (fullmakter)
+    }
+}
+
+private val dummyIdent = FullmektigStubs.gyldig.fullmektigIdent

--- a/src/test/kotlin/no/nav/tilleggsstonader/klage/infrastruktur/config/FullmaktClientConfig.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/klage/infrastruktur/config/FullmaktClientConfig.kt
@@ -1,0 +1,25 @@
+package no.nav.tilleggsstonader.klage.infrastruktur.config
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.tilleggsstonader.klage.fullmakt.FullmaktClient
+import no.nav.tilleggsstonader.klage.testutil.FullmektigStubs
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
+import org.springframework.context.annotation.Profile
+
+@Configuration
+@Profile("mock-fullmakt")
+class FullmaktClientConfig {
+
+    @Bean
+    @Primary
+    fun fullmaktClient(): FullmaktClient {
+        val fullmaktClient = mockk<FullmaktClient>()
+
+        every { fullmaktClient.hentFullmektige(any()) } returns listOf(FullmektigStubs.gyldig)
+
+        return fullmaktClient
+    }
+}

--- a/src/test/kotlin/no/nav/tilleggsstonader/klage/personopplysninger/PersonopplysningerServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/klage/personopplysninger/PersonopplysningerServiceTest.kt
@@ -5,6 +5,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import no.nav.tilleggsstonader.klage.behandling.BehandlingService
 import no.nav.tilleggsstonader.klage.fagsak.FagsakService
+import no.nav.tilleggsstonader.klage.fullmakt.FullmaktService
 import no.nav.tilleggsstonader.klage.integrasjoner.TilleggsstonaderSakClient
 import no.nav.tilleggsstonader.klage.personopplysninger.dto.Adressebeskyttelse
 import no.nav.tilleggsstonader.klage.personopplysninger.dto.Folkeregisterpersonstatus
@@ -21,6 +22,7 @@ import no.nav.tilleggsstonader.klage.personopplysninger.pdl.VergemaalEllerFremti
 import no.nav.tilleggsstonader.klage.testutil.DomainUtil.behandling
 import no.nav.tilleggsstonader.klage.testutil.DomainUtil.defaultIdenter
 import no.nav.tilleggsstonader.klage.testutil.DomainUtil.fagsak
+import no.nav.tilleggsstonader.klage.testutil.FullmektigStubs
 import no.nav.tilleggsstonader.klage.testutil.PdlTestdataHelper.lagNavn
 import no.nav.tilleggsstonader.klage.testutil.PdlTestdataHelper.metadataGjeldende
 import no.nav.tilleggsstonader.klage.testutil.PdlTestdataHelper.pdlSøker
@@ -28,6 +30,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
+import java.util.UUID
 import no.nav.tilleggsstonader.klage.personopplysninger.pdl.Adressebeskyttelse as PdlAdressebeskyttelse
 import no.nav.tilleggsstonader.klage.personopplysninger.pdl.AdressebeskyttelseGradering as PdlAdressebeskyttelseGradering1
 import no.nav.tilleggsstonader.klage.personopplysninger.pdl.Folkeregisterpersonstatus as PdlFolkeregisterpersonstatus1
@@ -38,9 +41,16 @@ internal class PersonopplysningerServiceTest {
     private val fagsakService = mockk<FagsakService>()
     private val pdlClient = mockk<PdlClient>()
     private val tilleggsstonaderSakClient = mockk<TilleggsstonaderSakClient>()
+    private val fullmaktService = mockk<FullmaktService>()
 
     private val personopplysningerService =
-        PersonopplysningerService(behandlingService, fagsakService, pdlClient, tilleggsstonaderSakClient)
+        PersonopplysningerService(
+            behandlingService = behandlingService,
+            fagsakService = fagsakService,
+            pdlClient = pdlClient,
+            fullmaktService = fullmaktService,
+            tilleggsstonaderSakClient = tilleggsstonaderSakClient,
+        )
 
     private val fagsak = fagsak()
     private val behandling = behandling(fagsak)
@@ -52,6 +62,7 @@ internal class PersonopplysningerServiceTest {
         every { pdlClient.hentPerson(any(), any()) } returns lagPdlSøker()
         every { pdlClient.hentNavnBolk(any(), any()) } returns navnBolkResponse()
         every { tilleggsstonaderSakClient.erEgenAnsatt(any()) } returns true
+        every { fullmaktService.hentFullmektige(any()) } returns emptyList()
     }
 
     @Test
@@ -77,6 +88,17 @@ internal class PersonopplysningerServiceTest {
         assertThat(personopplysninger.fullmakt.single().navn).isEqualTo("fullmakt etternavn")
 
         verify(exactly = 1) { pdlClient.hentNavnBolk(eq(listOf("fullmaktIdent")), any()) }
+    }
+
+    @Test
+    fun `har fullmektig hvis det finnes gyldige fullmakter`() {
+        every { fullmaktService.hentFullmektige(any()) } returns listOf(FullmektigStubs.gyldig)
+        assertThat(personopplysningerService.hentPersonopplysninger(behandling.id).harFullmektig).isTrue
+    }
+
+    @Test
+    fun `har ikke fullmektig hvis lista med fullmektige er tom`() {
+        assertThat(personopplysningerService.hentPersonopplysninger(behandling.id).harFullmektig).isFalse
     }
 
     private fun navnBolkResponse() = mapOf(

--- a/src/test/kotlin/no/nav/tilleggsstonader/klage/testutil/DomainUtil.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/klage/testutil/DomainUtil.kt
@@ -219,7 +219,12 @@ object DomainUtil {
 
     fun journalpostDokument(
         status: Dokumentstatus = Dokumentstatus.FERDIGSTILT,
-        dokumentvarianter: List<Dokumentvariant>? = listOf(Dokumentvariant(Dokumentvariantformat.ARKIV, saksbehandlerHarTilgang = true)),
+        dokumentvarianter: List<Dokumentvariant>? = listOf(
+            Dokumentvariant(
+                Dokumentvariantformat.ARKIV,
+                saksbehandlerHarTilgang = true,
+            ),
+        ),
     ) = DokumentInfo(
         dokumentInfoId = UUID.randomUUID().toString(),
         tittel = "Tittel",
@@ -257,6 +262,7 @@ object DomainUtil {
         fullmakt = emptyList(),
         egenAnsatt = false,
         vergemål = emptyList(),
+        harFullmektig = true,
     )
 
     fun fagsystemVedtak(

--- a/src/test/kotlin/no/nav/tilleggsstonader/klage/testutil/FullmektigStubs.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/klage/testutil/FullmektigStubs.kt
@@ -1,0 +1,20 @@
+package no.nav.tilleggsstonader.klage.testutil
+
+import no.nav.tilleggsstonader.kontrakter.fullmakt.FullmektigDto
+import java.time.LocalDate.now
+import java.time.LocalDate.parse
+
+object FullmektigStubs {
+    val gyldig = FullmektigDto(
+        fullmektigIdent = "12345678910",
+        fullmektigNavn = "Maud-Rita",
+        gyldigFraOgMed = parse("2023-01-01"),
+        gyldigTilOgMed = now().plusYears(10),
+        temaer = listOf("TSO"),
+    )
+    val gyldigPåUbestemtTid = gyldig.copy(gyldigTilOgMed = null)
+    val ikkeGyldigEnda = gyldig.copy(gyldigFraOgMed = now().plusDays(10))
+    val utgått = gyldig.copy(gyldigTilOgMed = now().minusYears(1))
+    val ikkeRelevantTema = gyldig.copy(temaer = listOf("AAP"))
+    val medFlereTemaer = gyldig.copy(temaer = listOf("AAP", "XXX", "TSR"))
+}


### PR DESCRIPTION
slik at frontend skal kunne vise fullmakt-tag i headeren. Data på fullmakter har blitt tatt over av representasjonsløsningen (REPR) og skal fases bort fra PDL.