### PR TITLE
Lagt til håndtering av omgjøring

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent
 val javaVersion = 21
 val familieProsesseringVersion = "2.20241011144712_deb1f2c"
 val tilleggsstønaderLibsVersion = "2024.10.30-09.56.91115fdcae1e"
-val tilleggsstønaderKontrakterVersion = "2024.10.31-11.26.7172148519ea"
+val tilleggsstønaderKontrakterVersion = "2024.12.05-14.47.8af9a5d9f178"
 val tokenSupportVersion = "5.0.8"
 val wiremockVersion = "3.9.2"
 val mockkVersion = "1.13.13"

--- a/src/main/kotlin/no/nav/tilleggsstonader/klage/kabal/KabalKafkaListener.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/klage/kabal/KabalKafkaListener.kt
@@ -86,6 +86,7 @@ data class BehandlingEvent(
             BehandlingEventType.BEHANDLING_FEILREGISTRERT -> detaljer.behandlingFeilregistrert?.feilregistrert ?: throw Feil("Fant ikke tidspunkt for feilregistrering")
             BehandlingEventType.BEHANDLING_ETTER_TRYGDERETTEN_OPPHEVET_AVSLUTTET ->
                 detaljer.behandlingEtterTrygderettenOpphevetAvsluttet?.avsluttet ?: throw Feil(feilmelding)
+            BehandlingEventType.OMGJOERINGSKRAV_AVSLUTTET -> detaljer.omgjoeringskravbehandlingAvsluttet?.avsluttet ?: throw Feil("Ikke implementert for OMGJOERINGSKRAV_AVSLUTTET")
         }
     }
 
@@ -114,6 +115,7 @@ data class BehandlingDetaljer(
     val behandlingFeilregistrert: BehandlingFeilregistrertDetaljer? = null,
     val ankeITrygderettenbehandlingOpprettet: AnkeITrygderettenbehandlingOpprettetDetaljer? = null,
     val behandlingEtterTrygderettenOpphevetAvsluttet: BehandlingEtterTrygderettenOpphevetAvsluttetDetaljer? = null,
+    val omgjoeringskravbehandlingAvsluttet: OmgjoeringskravbehandlingAvsluttetDetaljer? = null,
 ) {
 
     fun oppgaveTekst(saksbehandlersEnhet: String): String {
@@ -178,4 +180,16 @@ data class BehandlingEtterTrygderettenOpphevetAvsluttetDetaljer(
             "Opprinnelig klagebehandling er behandlet av enhet: $saksbehandlersEnhet. " +
             "Journalpost referanser: ${journalpostReferanser.joinToString(", ")}"
     }
+}
+
+data class OmgjoeringskravbehandlingAvsluttetDetaljer(
+    val avsluttet: LocalDateTime,
+    val utfall: KlageinstansUtfall,
+    val journalpostReferanser: List<String>,
+) {
+    fun oppgaveTekst(saksbehandlersEnhet: String) =
+        "Hendelse fra klage etter omgjøringskrav med utfall $utfall mottatt. " +
+            "Avsluttet tidspunkt: $avsluttet. " +
+            "Opprinnelig klagebehandling er behandlet av enhet: $saksbehandlersEnhet. " +
+            "Journalpost referanser: ${journalpostReferanser.joinToString(", ")}"
 }

--- a/src/main/kotlin/no/nav/tilleggsstonader/klage/kabal/domain/OversendtKlage.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/klage/kabal/domain/OversendtKlage.kt
@@ -26,6 +26,7 @@ enum class Type(val beskrivelse: String) {
     KLAGE("Klage"),
     ANKE("Anke"),
     ANKE_I_TRYGDERETTEN("Anke i trygderetten"),
+    OMGJOERINGSKRAV("Omgjoeringskrav"),
 }
 
 enum class OversendtPartIdType {

--- a/src/main/kotlin/no/nav/tilleggsstonader/klage/kabal/event/BehandlingEventService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/klage/kabal/event/BehandlingEventService.kt
@@ -53,6 +53,7 @@ class BehandlingEventService(
                 BehandlingEventType.KLAGEBEHANDLING_AVSLUTTET -> behandleKlageAvsluttet(behandling, behandlingEvent)
                 BehandlingEventType.ANKEBEHANDLING_AVSLUTTET,
                 BehandlingEventType.BEHANDLING_ETTER_TRYGDERETTEN_OPPHEVET_AVSLUTTET,
+                BehandlingEventType.OMGJOERINGSKRAV_AVSLUTTET,
                 -> opprettOppgaveTask(behandling, behandlingEvent)
 
                 BehandlingEventType.ANKEBEHANDLING_OPPRETTET,

--- a/src/test/kotlin/no/nav/tilleggsstonader/klage/kabal/event/BehandlingEventServiceTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/klage/kabal/event/BehandlingEventServiceTest.kt
@@ -20,6 +20,7 @@ import no.nav.tilleggsstonader.klage.kabal.BehandlingFeilregistrertDetaljer
 import no.nav.tilleggsstonader.klage.kabal.BehandlingFeilregistrertTask
 import no.nav.tilleggsstonader.klage.kabal.KlagebehandlingAvsluttetDetaljer
 import no.nav.tilleggsstonader.klage.kabal.KlageresultatRepository
+import no.nav.tilleggsstonader.klage.kabal.OmgjoeringskravbehandlingAvsluttetDetaljer
 import no.nav.tilleggsstonader.klage.kabal.Type
 import no.nav.tilleggsstonader.klage.kabal.domain.KlageinstansResultat
 import no.nav.tilleggsstonader.klage.oppgave.OpprettKabalEventOppgaveTask
@@ -138,6 +139,28 @@ internal class BehandlingEventServiceTest {
         verify(exactly = 1) { klageresultatRepository.insert(capture(klageinstansResultatSlot)) }
 
         assertThat(klageinstansResultatSlot.captured.type).isEqualTo(BehandlingEventType.ANKE_I_TRYGDERETTENBEHANDLING_OPPRETTET)
+    }
+
+    @Test
+    internal fun `Skal kunne lagre resultat for behandlingsevent omgjøringskrav`() {
+        val klageinstansResultatSlot = slot<KlageinstansResultat>()
+
+        val omgjoeringskravbehandlingAvsluttet = OmgjoeringskravbehandlingAvsluttetDetaljer(
+            LocalDateTime.of(2023, 6, 21, 1, 1),
+            KlageinstansUtfall.HEVET,
+            emptyList(),
+        )
+        behandlingEventService.handleEvent(
+            lagBehandlingEvent(
+                BehandlingEventType.OMGJOERINGSKRAV_AVSLUTTET,
+                BehandlingDetaljer(omgjoeringskravbehandlingAvsluttet = omgjoeringskravbehandlingAvsluttet),
+            ),
+        )
+
+        verify(exactly = 1) { behandlingRepository.findByEksternBehandlingId(any()) }
+        verify(exactly = 1) { klageresultatRepository.insert(capture(klageinstansResultatSlot)) }
+
+        assertThat(klageinstansResultatSlot.captured.type).isEqualTo(BehandlingEventType.OMGJOERINGSKRAV_AVSLUTTET)
     }
 
     @Test


### PR DESCRIPTION
Nytt utfall og type fra KA -> medhold etter omgjøringskrav. (https://github.com/navikt/familie-kontrakter/pull/965)
"Medhold etter fvl. § 35 KA"
Brukere kan sende krav om at klageinstansen omgjør et av sine tidligere vedtak, og dette kalles omgjøringskrav. Dersom et omgjøringskrav fører til et medhold, må vedtaksinstans kobles på for å effektuere. familie-klage må kunne håndtere hendelser med denne typen og dette utfallet.

https://nav-it.slack.com/archives/C058Z17RTSR/p1731332841782139

Lesing av kafka feiler nå i dev
https://logs.adeo.no/s/nav-logs-legacy/app/r/s/1VuNZ

Liknende som
* https://github.com/navikt/familie-klage/pull/535