### PR TITLE
✨ Legg til støtte for GAMMEL_MANGLER_DATA i formkrav og oppdater rela…

### DIFF
--- a/src/main/kotlin/no/nav/tilleggsstonader/klage/formkrav/FormService.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/klage/formkrav/FormService.kt
@@ -64,6 +64,9 @@ class FormService(
                 vurderingService.slettVurderingForBehandling(behandlingId)
                 stegService.oppdaterSteg(behandlingId, StegType.FORMKRAV, StegType.FORMKRAV)
             }
+            FormVilkår.GAMMEL_MANGLER_DATA -> {
+                stegService.oppdaterSteg(behandlingId, StegType.FORMKRAV, StegType.FORMKRAV)
+            }
         }
 
         opprettBehandlingsstatistikk(behandlingId)

--- a/src/main/kotlin/no/nav/tilleggsstonader/klage/formkrav/FormUtil.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/klage/formkrav/FormUtil.kt
@@ -25,11 +25,13 @@ object FormUtil {
     }
 
     fun alleVilkårOppfylt(formkrav: Form): Boolean =
-        formkrav.alleSvar().all { it == FormVilkår.OPPFYLT } ||
+        formkrav.alleSvar().all { it.erOppfyltEllerGammel() } ||
             (alleVilkårOppfyltUntattKlagefrist(formkrav) && klagefristUnntakOppfylt(formkrav.klagefristOverholdtUnntak))
 
     private fun alleVilkårOppfyltUntattKlagefrist(formkrav: Form) =
-        formkrav.alleSvarBortsettFraFrist().all { it == FormVilkår.OPPFYLT } && formkrav.klagefristOverholdt == FormVilkår.IKKE_OPPFYLT
+        formkrav.alleSvarBortsettFraFrist().all { it.erOppfyltEllerGammel() } && formkrav.klagefristOverholdt == FormVilkår.IKKE_OPPFYLT
+
+    private fun FormVilkår.erOppfyltEllerGammel() = this == FormVilkår.OPPFYLT || this == FormVilkår.GAMMEL_MANGLER_DATA
 
     private fun klagefristUnntakOppfylt(unntak: FormkravFristUnntak) =
         when (unntak) {

--- a/src/main/kotlin/no/nav/tilleggsstonader/klage/formkrav/domain/Form.kt
+++ b/src/main/kotlin/no/nav/tilleggsstonader/klage/formkrav/domain/Form.kt
@@ -31,4 +31,5 @@ enum class FormVilkår {
     OPPFYLT,
     IKKE_OPPFYLT,
     IKKE_SATT,
+    GAMMEL_MANGLER_DATA,
 }

--- a/src/main/resources/db/migration/V26__gammel_mangler_data_klagers_rettslig_interesse.sql
+++ b/src/main/resources/db/migration/V26__gammel_mangler_data_klagers_rettslig_interesse.sql
@@ -1,0 +1,3 @@
+UPDATE form
+SET klagers_rettslig_interesse = 'GAMMEL_MANGLER_DATA'
+WHERE klagers_rettslig_interesse = 'IKKE_SATT';

--- a/src/test/kotlin/no/nav/tilleggsstonader/klage/formkrav/FormUtilTest.kt
+++ b/src/test/kotlin/no/nav/tilleggsstonader/klage/formkrav/FormUtilTest.kt
@@ -72,6 +72,30 @@ internal class FormUtilTest {
         }
 
         @Test
+        internal fun `GAMMEL_MANGLER_DATA på klagersRettsligInteresse skal behandles som oppfylt`() {
+            val gammelForm = oppfyltForm.copy(klagersRettsligInteresse = FormVilkår.GAMMEL_MANGLER_DATA)
+            assertThat(alleVilkårOppfylt(gammelForm)).isTrue
+        }
+
+        @Test
+        internal fun `GAMMEL_MANGLER_DATA kombinert med ikke overholdt frist og unntak skal behandles som oppfylt`() {
+            val gammelForm =
+                oppfyltForm.copy(
+                    klagersRettsligInteresse = FormVilkår.GAMMEL_MANGLER_DATA,
+                    klagefristOverholdt = FormVilkår.IKKE_OPPFYLT,
+                    klagefristOverholdtUnntak = FormkravFristUnntak.UNNTAK_SÆRLIG_GRUNN,
+                )
+            assertThat(alleVilkårOppfylt(gammelForm)).isTrue
+        }
+
+        @Test
+        internal fun `GAMMEL_MANGLER_DATA på andre vilkår enn klagersRettsligInteresse skal behandles som oppfylt`() {
+            assertThat(alleVilkårOppfylt(oppfyltForm.copy(klagePart = FormVilkår.GAMMEL_MANGLER_DATA))).isTrue
+            assertThat(alleVilkårOppfylt(oppfyltForm.copy(klageKonkret = FormVilkår.GAMMEL_MANGLER_DATA))).isTrue
+            assertThat(alleVilkårOppfylt(oppfyltForm.copy(klageSignert = FormVilkår.GAMMEL_MANGLER_DATA))).isTrue
+        }
+
+        @Test
         internal fun `formkrav om overholdt frist er ikke oppfylt`() {
             val ikkeOppfyltFrist = oppfyltForm.copy(klagefristOverholdt = FormVilkår.IKKE_OPPFYLT)
             val toFormKravIkkeOppfylt = ikkeOppfyltFrist.copy(klageKonkret = FormVilkår.IKKE_OPPFYLT)


### PR DESCRIPTION
…terte tester

legge til GAMMEL_MANGLER_DATA som blir satt på alle gamle klager før klagers rettslig interesse ble lagt til så man kan gå inn på lesevisning på  gamle ferdige klagebehandlinger